### PR TITLE
Fix: compiler warning for return value of system(3)

### DIFF
--- a/include/tetris.hpp
+++ b/include/tetris.hpp
@@ -15,6 +15,8 @@
 #include <cstring>
 #include <algorithm>
 #include <unistd.h>
+#include <errno.h>
+#include <cstring>
 
 using namespace std;
 

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -18,8 +18,14 @@ void checkNext(int startLevel, bool easy, string basename) {
         systring += " --easy";
     
     // perform action based on input
-    if ( ch == 'y' )
-        system(systring.c_str()); // call binary
+    if ( ch == 'y' ) {
+        // call binary
+        if (system(systring.c_str()) == -1) {
+            cerr << "Error calling '" << systring << "': "
+                 << strerror(errno) << endl;
+            exit(EXIT_FAILURE);
+        }
+    }
     else if ( ch == 'n' )
         return; // exit out of program
     else // did not input y or n, try again


### PR DESCRIPTION
This is to silence the compiler warning for `-Wunused-result` for the return value of `system`. This only handles the error state of `-1`.